### PR TITLE
mbop/foreach.here

### DIFF
--- a/doc/exmdb_provider.4gx
+++ b/doc/exmdb_provider.4gx
@@ -1,5 +1,5 @@
 .\" SPDX-License-Identifier: CC-BY-SA-4.0 or-later
-.\" SPDX-FileCopyrightText: 2020-2022 grommunio GmbH
+.\" SPDX-FileCopyrightText: 2020–2025 grommunio GmbH
 .TH exmdb_provider 4gx "" "Gromox" "Gromox admin reference"
 .SH Name
 exmdb_provider \(em Gromox Information Store
@@ -122,6 +122,17 @@ messages, on a 3700X CPU, single-thread. The file can also temporarily grow to
 double its size, so ample disk space may be required.)
 .br
 Default: \fIyes\fP
+.TP
+\fBexmdb_eph_prefix\fP
+A path for where variadic data files that are process-temporary can be stored.
+This may be used to keep the tables.sqlite3 file off an NFS-backed homedir.
+Required disk space scales linearly with open table handles and linearly with
+messages in the opened folders, at about 80 bytes per messages. (In other
+words, don't lump molasses of messages into a single folder in a shared mailbox
+read by multiple people.) When you create the directory, set its ownership to
+gromox:gromox and mode to 0770.
+.br
+Default: (empty)
 .TP
 \fBexmdb_search_pacing\fP
 When initially populating a search folder (static or dynamic), yield the lock

--- a/exch/exmdb/db_engine.hpp
+++ b/exch/exmdb/db_engine.hpp
@@ -233,7 +233,7 @@ extern unsigned int g_exmdb_schema_upgrades, g_exmdb_search_pacing;
 extern unsigned long long g_exmdb_search_pacing_time, g_exmdb_lock_timeout;
 extern unsigned int g_exmdb_search_yield, g_exmdb_search_nice;
 extern unsigned int g_exmdb_pvt_folder_softdel;
-extern std::string g_exmdb_ics_log_file;
+extern std::string g_exmdb_ics_log_file, exmdb_eph_prefix;
 /* Max number of cached DB connections per store, 0 = unlimited */
 extern unsigned int g_exmdb_max_sqlite_spares;
 extern unsigned long long g_sqlite_busy_timeout_ns;

--- a/exch/exmdb/main.cpp
+++ b/exch/exmdb/main.cpp
@@ -47,6 +47,7 @@ static constexpr cfg_directive exmdb_cfg_defaults[] = {
 	{"dbg_synthesize_content", "0"},
 	{"enable_dam", "1", CFG_BOOL},
 	{"exmdb_body_autosynthesis", "1", CFG_BOOL},
+	{"exmdb_eph_prefix", ""},
 	{"exmdb_file_compression", "zstd-6"},
 	{"exmdb_hosts_allow", ""}, /* ::1 default set later during startup */
 	{"exmdb_listen_port", "5000"},
@@ -112,6 +113,7 @@ static bool exmdb_provider_reload(std::shared_ptr<config_file> gxcfg = nullptr,
 	g_exmdb_search_pacing_time = pconfig->get_ll("exmdb_search_pacing_time");
 	g_exmdb_max_sqlite_spares = pconfig->get_ll("exmdb_max_sqlite_spares");
 	g_sqlite_busy_timeout_ns = pconfig->get_ll("sqlite_busy_timeout");
+	exmdb_eph_prefix = pconfig->get_value("exmdb_eph_prefix");
 	gx_sql_deep_backtrace = gxcfg->get_ll("exmdb_deep_backtrace");
 	gx_force_write_txn = gxcfg->get_ll("exmdb_force_write_txn");
 	auto s = gxcfg->get_value("exmdb_ics_log_file");

--- a/exch/exmdb/store2.cpp
+++ b/exch/exmdb/store2.cpp
@@ -733,6 +733,11 @@ static BOOL autoreply_setprop1(const char *dir, const TAGGED_PROPVAL &pv)
 	auto path = autoreply_fspath(dir, pv.proptag);
 
 	/* Ensure file exists for the sake of config_file_init() */
+	auto ret = gx_mkbasedir(path.c_str(), FMODE_PRIVATE | S_IXUSR | S_IXGRP);
+	if (ret < 0) {
+		mlog(LV_ERR, "E-1490: mkbasedir for %s: %s", path.c_str(), strerror(-ret));
+		return false;
+	}
 	auto fdtest = open(path.c_str(), O_CREAT | O_WRONLY, FMODE_PUBLIC);
 	if (fdtest < 0)
 		return false;

--- a/exch/exmdb/table.cpp
+++ b/exch/exmdb/table.cpp
@@ -33,7 +33,6 @@
 #include "db_engine.hpp"
 #include "parser.hpp"
 
-using namespace std::string_literals;
 using LLU = unsigned long long;
 using namespace gromox;
 
@@ -3033,7 +3032,7 @@ BOOL exmdb_server::store_table_state(const char *dir, uint32_t table_id,
 		return TRUE;
 	if (ptnode->type != table_type::content)
 		return TRUE;
-	const auto &state_path = exmdb_server::get_dir() + "/tmp/state.sqlite3"s;
+	const auto &state_path = exmdb_eph_prefix + "/" + exmdb_server::get_dir() + "/tablestate.sqlite3";
 	auto ret = gx_mkbasedir(state_path.c_str(), FMODE_PRIVATE | S_IXUSR | S_IXGRP);
 	if (ret < 0) {
 		mlog(LV_ERR, "E-2711: mkbasedir %s: %s", state_path.c_str(), strerror(-ret));
@@ -3322,7 +3321,7 @@ BOOL exmdb_server::restore_table_state(const char *dir, uint32_t table_id,
 		return TRUE;
 	if (ptnode->type != table_type::content)
 		return TRUE;
-	const auto &state_path = exmdb_server::get_dir() + "/tmp/state.sqlite3"s;
+	const auto &state_path = exmdb_eph_prefix + "/" + exmdb_server::get_dir() + "/tablestate.sqlite3";
 	if (stat(state_path.c_str(), &node_stat) != 0)
 		return TRUE;
 	sqlite3 *psqlite = nullptr;

--- a/exch/exmdb/table.cpp
+++ b/exch/exmdb/table.cpp
@@ -33,6 +33,7 @@
 #include "db_engine.hpp"
 #include "parser.hpp"
 
+using namespace std::string_literals;
 using LLU = unsigned long long;
 using namespace gromox;
 
@@ -3008,9 +3009,8 @@ BOOL exmdb_server::collapse_table(const char *dir,
 	return sql_transact_eph.commit() == SQLITE_OK ? TRUE : false;
 }
 
-BOOL exmdb_server::store_table_state(const char *dir,
-	uint32_t table_id, uint64_t inst_id,
-	uint32_t inst_num, uint32_t *pstate_id)
+BOOL exmdb_server::store_table_state(const char *dir, uint32_t table_id,
+    uint64_t inst_id, uint32_t inst_num, uint32_t *pstate_id) try
 {
 	int depth;
 	void *pvalue;
@@ -3019,7 +3019,6 @@ BOOL exmdb_server::store_table_state(const char *dir,
 	uint64_t last_id;
 	sqlite3 *psqlite;
 	EXT_PUSH ext_push;
-	char tmp_path[256];
 	char tmp_buff[1024];
 	uint32_t tmp_proptag;
 	char sql_string[1024];
@@ -3034,18 +3033,17 @@ BOOL exmdb_server::store_table_state(const char *dir,
 		return TRUE;
 	if (ptnode->type != table_type::content)
 		return TRUE;
-	snprintf(tmp_path, std::size(tmp_path), "%s/tmp/state.sqlite3",
-	         exmdb_server::get_dir());
+	const auto &state_path = exmdb_server::get_dir() + "/tmp/state.sqlite3"s;
 	/*
 	 * sqlite3_open does not expose O_EXCL, so let's create the file under
 	 * EXCL semantics ahead of time.
 	 */
-	auto tfd = open(tmp_path, O_RDWR | O_CREAT | O_EXCL, FMODE_PRIVATE);
+	auto tfd = open(state_path.c_str(), O_RDWR | O_CREAT | O_EXCL, FMODE_PRIVATE);
 	if (tfd >= 0) {
 		close(tfd);
-		auto ret = sqlite3_open_v2(tmp_path, &psqlite, SQLITE_OPEN_READWRITE, nullptr);
+		auto ret = sqlite3_open_v2(state_path.c_str(), &psqlite, SQLITE_OPEN_READWRITE, nullptr);
 		if (ret != SQLITE_OK) {
-			mlog(LV_ERR, "E-1435: sqlite3_open %s: %s", tmp_path, sqlite3_errstr(ret));
+			mlog(LV_ERR, "E-1435: sqlite3_open %s: %s", state_path.c_str(), sqlite3_errstr(ret));
 			return FALSE;
 		}
 		gx_sql_exec(psqlite, "PRAGMA journal_mode=OFF");
@@ -3062,27 +3060,27 @@ BOOL exmdb_server::store_table_state(const char *dir,
 			"header_stat INTEGER DEFAULT NULL)");
 		if (gx_sql_exec(psqlite, sql_string) != SQLITE_OK) {
 			sqlite3_close(psqlite);
-			if (remove(tmp_path) < 0 && errno != ENOENT)
-				mlog(LV_WARN, "W-1348: remove %s: %s", tmp_path, strerror(errno));
+			if (remove(state_path.c_str()) < 0 && errno != ENOENT)
+				mlog(LV_WARN, "W-1348: remove %s: %s", state_path.c_str(), strerror(errno));
 			return FALSE;
 		}
 		snprintf(sql_string, std::size(sql_string), "CREATE UNIQUE INDEX state_index"
 			" ON state_info (folder_id, table_flags, sorts)");
 		if (gx_sql_exec(psqlite, sql_string) != SQLITE_OK) {
 			sqlite3_close(psqlite);
-			remove(tmp_path);
+			remove(state_path.c_str());
 			return FALSE;
 		}
 	} else if (errno == EEXIST) {
-		auto ret = sqlite3_open_v2(tmp_path, &psqlite, SQLITE_OPEN_READWRITE, nullptr);
+		auto ret = sqlite3_open_v2(state_path.c_str(), &psqlite, SQLITE_OPEN_READWRITE, nullptr);
 		if (ret != SQLITE_OK) {
-			mlog(LV_ERR, "E-1436: sqlite3_open %s: %s", tmp_path, sqlite3_errstr(ret));
+			mlog(LV_ERR, "E-1436: sqlite3_open %s: %s", state_path.c_str(), sqlite3_errstr(ret));
 			return FALSE;
 		}
 		gx_sql_exec(psqlite, "PRAGMA journal_mode=OFF");
 		gx_sql_exec(psqlite, "PRAGMA synchronous=OFF");
 	} else {
-		mlog(LV_ERR, "E-1943: open %s: %s", tmp_path, strerror(errno));
+		mlog(LV_ERR, "E-1943: open %s: %s", state_path.c_str(), strerror(errno));
 		return false;
 	}
 	auto cl_0 = HX::make_scope_exit([&]() { sqlite3_close(psqlite); });
@@ -3282,10 +3280,12 @@ BOOL exmdb_server::store_table_state(const char *dir,
 		sqlite3_reset(pstmt1);
 	}
 	return sql_transact.commit() == SQLITE_OK ? TRUE : false;
+} catch (const std::bad_alloc &) {
+	return false;
 }
 
-BOOL exmdb_server::restore_table_state(const char *dir,
-	uint32_t table_id, uint32_t state_id, int32_t *pposition)
+BOOL exmdb_server::restore_table_state(const char *dir, uint32_t table_id,
+    uint32_t state_id, int32_t *pposition) try
 {
 	void *pvalue;
 	uint32_t idx;
@@ -3295,7 +3295,6 @@ BOOL exmdb_server::restore_table_state(const char *dir,
 	uint8_t row_stat;
 	uint64_t inst_num;
 	EXT_PUSH ext_push;
-	char tmp_path[256];
 	uint64_t header_id;
 	uint64_t message_id;
 	uint8_t header_stat;
@@ -3318,15 +3317,14 @@ BOOL exmdb_server::restore_table_state(const char *dir,
 		return TRUE;
 	if (ptnode->type != table_type::content)
 		return TRUE;
-	snprintf(tmp_path, std::size(tmp_path), "%s/tmp/state.sqlite3",
-	         exmdb_server::get_dir());
-	if (stat(tmp_path, &node_stat) != 0)
+	const auto &state_path = exmdb_server::get_dir() + "/tmp/state.sqlite3"s;
+	if (stat(state_path.c_str(), &node_stat) != 0)
 		return TRUE;
 	sqlite3 *psqlite = nullptr;
-	auto ret = sqlite3_open_v2(tmp_path, &psqlite, SQLITE_OPEN_READWRITE, nullptr);
+	auto ret = sqlite3_open_v2(state_path.c_str(), &psqlite, SQLITE_OPEN_READWRITE, nullptr);
 	if (ret != SQLITE_OK) {
-		mlog(LV_ERR, "E-1437: sqlite3_open %s: %s", tmp_path, sqlite3_errstr(ret));
-		return FALSE;
+		mlog(LV_ERR, "E-1437: sqlite3_open %s: %s", state_path.c_str(), sqlite3_errstr(ret));
+		return false;
 	}
 	auto cl_0 = HX::make_scope_exit([&]() { sqlite3_close(psqlite); });
 	gx_sql_exec(psqlite, "PRAGMA journal_mode=OFF");
@@ -3514,4 +3512,6 @@ BOOL exmdb_server::restore_table_state(const char *dir,
 		return false;
 	*pposition = pstmt.step() == SQLITE_ROW ? sqlite3_column_int64(pstmt, 0) - 1 : -1;
 	return TRUE;
+} catch (const std::bad_alloc &) {
+	return false;
 }

--- a/include/gromox/json.hpp
+++ b/include/gromox/json.hpp
@@ -6,4 +6,5 @@ namespace gromox {
 extern GX_EXPORT bool json_from_str(std::string_view, Json::Value &);
 extern GX_EXPORT std::string json_to_str(const Json::Value &);
 extern GX_EXPORT bool get_digest(const Json::Value &src, const char *tag, char *out, size_t outmax);
+extern GX_EXPORT bool get_digest(const Json::Value &src, const char *tag, std::string &out);
 }

--- a/lib/rfbl.cpp
+++ b/lib/rfbl.cpp
@@ -965,6 +965,17 @@ int iconv_validate()
 	return 0;
 }
 
+bool get_digest(const Json::Value &jval, const char *key, std::string &out) try
+{
+	if (jval.type() != Json::ValueType::objectValue || !jval.isMember(key))
+		return false;
+	out = jval[key].asString();
+	return TRUE;
+} catch (const std::bad_alloc &) {
+	mlog(LV_ERR, "E-1988: ENOMEM");
+	return false;
+}
+
 bool get_digest(const Json::Value &jval, const char *key, char *out, size_t outmax) try
 {
 	if (jval.type() != Json::ValueType::objectValue || !jval.isMember(key))

--- a/mra/midb_agent.cpp
+++ b/mra/midb_agent.cpp
@@ -1107,14 +1107,6 @@ static std::string flagbits_to_s(unsigned int v)
 	return s;
 }
 
-static bool get_digest_string(const Json::Value &jv, const char *tag, std::string &buff)
-{
-	if (jv.type() != Json::ValueType::objectValue || !jv.isMember(tag))
-		return false;
-	buff = jv[tag].asString();
-	return true;
-}
-
 static bool get_digest_integer(const Json::Value &jv, const char *tag, int &i)
 {
 	if (jv.type() != Json::ValueType::objectValue || !jv.isMember(tag))
@@ -1466,7 +1458,7 @@ int fetch_detail_uid(const char *path, const std::string &folder,
 					if (pspace == nullptr ||
 					    !json_from_str(std::string_view(&pspace[1], temp_len), mitem.digest)) {
 						b_format_error = TRUE;
-					} else if (get_digest_string(mitem.digest, "file", mitem.mid) &&
+					} else if (get_digest(mitem.digest, "file", mitem.mid) &&
 					    get_digest_integer(mitem.digest, "uid", mitem.uid)) {
 						*pspace++ = '\0';
 						auto mitem_uid = mitem.uid;

--- a/tools/mbop_foreach.cpp
+++ b/tools/mbop_foreach.cpp
@@ -33,7 +33,7 @@ static int help()
 {
 	fprintf(stderr, "Usage: foreach[.filter]* [-j jobs] command [args...]\n");
 	fprintf(stderr, " filter := secobj | user | mlist | sharedmb | contact |\n");
-	fprintf(stderr, "           active | susp | deleted | mb\n");
+	fprintf(stderr, "           active | susp | deleted | mb | here\n");
 	global::command_overview();
 	return EXIT_PARAM;
 }


### PR DESCRIPTION
- **mra: move get_digest with std::string output to lib/**
- **exmdb: switch filename construction buffers to std::string**
- **exmdb: switch filename construction buffers to std::string (2)**
- **exmdb: create internal user subdirs as needed**
- **exmdb: add ephemeral storage location**
- **mbop.foreach add "here" to filter help**
